### PR TITLE
Add ability to query individual regulation pages in GraphQL

### DIFF
--- a/regulations_example/api/schema.py
+++ b/regulations_example/api/schema.py
@@ -31,9 +31,18 @@ class RegulationPageType(DjangoObjectType):
 
 class Query(graphene.ObjectType):
     regulations = graphene.List(RegulationPageType)
+    regulation = graphene.Field(
+        RegulationPageType, id=graphene.Int(), slug=graphene.String()
+    )
 
     def resolve_regulations(self, info):
         return TestRegulationPage.objects.live()
+
+    def resolve_regulation(self, info, id=None, slug=None):
+        if id is not None:
+            return TestRegulationPage.objects.live().get(id=id)
+        if slug is not None:
+            return TestRegulationPage.objects.live().get(slug=slug)
 
 
 schema = graphene.Schema(query=Query)

--- a/regulations_example/api/schema.py
+++ b/regulations_example/api/schema.py
@@ -5,7 +5,7 @@ from graphene.types import Scalar
 from graphene_django import DjangoObjectType
 from graphene_django.converter import convert_django_field
 from regulations_example.models import TestRegulationPage
-from wagtailregulations.api.schema import PartNode
+from wagtailregulations.api.schema import PartType
 
 
 class GenericStreamFieldType(Scalar):
@@ -21,8 +21,8 @@ def convert_stream_field(field, registry=None):
     )
 
 
-class RegulationNode(DjangoObjectType):
-    regulation = graphene.Field(PartNode)
+class RegulationPageType(DjangoObjectType):
+    regulation = graphene.Field(PartType)
 
     class Meta:
         model = TestRegulationPage
@@ -30,10 +30,9 @@ class RegulationNode(DjangoObjectType):
 
 
 class Query(graphene.ObjectType):
-    regulations = graphene.List(RegulationNode)
+    regulations = graphene.List(RegulationPageType)
 
-    @graphene.resolve_only_args
-    def resolve_regulations(self):
+    def resolve_regulations(self, info):
         return TestRegulationPage.objects.live()
 
 

--- a/regulations_example/urls.py
+++ b/regulations_example/urls.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.conf.urls import include, re_path
 from django.contrib import admin
+from django.views.decorators.csrf import csrf_exempt
 
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.core import urls as wagtail_urls
@@ -16,7 +17,10 @@ urlpatterns = [
     re_path(r"^admin/", include(wagtailadmin_urls)),
     re_path(r"^documents/", include(wagtaildocs_urls)),
     re_path(r"^api/v2/", api_router.urls),
-    re_path(r"^graphql", GraphQLView.as_view(graphiql=True, schema=schema)),
+    re_path(
+        r"^graphql",
+        csrf_exempt(GraphQLView.as_view(graphiql=True, schema=schema)),
+    ),
 ]
 
 

--- a/wagtailregulations/api/schema.py
+++ b/wagtailregulations/api/schema.py
@@ -5,7 +5,7 @@ from wagtailregulations.models import EffectiveVersion, Part, Section, Subpart
 from wagtailregulations.resolver import get_contents_resolver, get_url_resolver
 
 
-class SectionNode(DjangoObjectType):
+class SectionType(DjangoObjectType):
     class Meta:
         model = Section
         fields = (
@@ -29,7 +29,7 @@ class SectionNode(DjangoObjectType):
         return html_contents
 
 
-class SubpartNode(DjangoObjectType):
+class SubpartType(DjangoObjectType):
     class Meta:
         model = Subpart
         fields = (
@@ -39,7 +39,7 @@ class SubpartNode(DjangoObjectType):
         )
 
 
-class EffectiveVersionNode(DjangoObjectType):
+class EffectiveVersionType(DjangoObjectType):
     class Meta:
         model = EffectiveVersion
         fields = (
@@ -50,7 +50,7 @@ class EffectiveVersionNode(DjangoObjectType):
         )
 
 
-class PartNode(DjangoObjectType):
+class PartType(DjangoObjectType):
     class Meta:
         model = Part
         fields = (
@@ -62,7 +62,7 @@ class PartNode(DjangoObjectType):
             "versions",
         )
 
-    effective_version = graphene.Field(EffectiveVersionNode)
+    effective_version = graphene.Field(EffectiveVersionType)
 
     def resolve_effective_version(self, info):
         return self.effective_version

--- a/wagtailregulations/tests/test_api_schema.py
+++ b/wagtailregulations/tests/test_api_schema.py
@@ -126,3 +126,35 @@ class SchemaTestCase(GraphQLTestCase, RegulationsTestData):
         regulation = regulation_pages[0]["regulation"]
         section = regulation["effectiveVersion"]["subparts"][1]["sections"][0]
         self.assertIn("blockquote", section["renderedContents"])
+
+    def test_query_regulation_slug(self):
+        response = self.query(
+            f"""
+            query {{
+                regulation (slug: "{self.reg_page.slug}") {{
+                    id
+                }}
+            }}
+            """
+        )
+        self.assertResponseNoErrors(response)
+        content = json.loads(response.content)
+        self.assertEqual(
+            self.reg_page.id, int(content["data"]["regulation"]["id"])
+        )
+
+    def test_query_regulation_id(self):
+        response = self.query(
+            f"""
+            query {{
+                regulation (id: {self.reg_page.id}) {{
+                    slug
+                }}
+            }}
+            """
+        )
+        self.assertResponseNoErrors(response)
+        content = json.loads(response.content)
+        self.assertEqual(
+            self.reg_page.slug, content["data"]["regulation"]["slug"]
+        )


### PR DESCRIPTION
This adds the ability to query individual regulation pages by slug or id from the `regulations_example` GraphQL API. It supports both "id" (the primary key of the page) and the page's "slug":

```graphql
query {
  regulation (id: 4) {
    id
    slug
    body
  }
}
```

and

```graphql
query {
  regulation (slug: 1002) {
    id
    slug
    body
  }
}
```

This PR also makes the `regulations_example` `/graphql` endpoint `csrf_exempt`.

## Testing

1. Checkout this PR branch and then bring up Docker:

   ```
   docker-compose up
   docker-compose run app /venv/bin/python manage.py createsuperuser --username admin --email test@example.com
   docker-compose run app /venv/bin/python manage.py loaddata sample_data.json
   ```
2. Visit http://localhost:8000/graphql
3. Query using either of the queries above. You should get back:

   ```graphql
   {
     "data": {
       "regulation": {
         "id": "4",
         "slug": "1002",
         "body": [
           {
             "type": "title",
             "value": "12 CFR Part 1002 - Equal Credit Opportunity Act (Regulation B)",
             "id": "0c160a0e-c159-4a8f-a422-7bb8a9a01743"
           },
           {
             "type": "introduction",
             "value": "<p>Regulation B protects applicants from discrimination in any aspect of a credit transaction.</p>",
             "id": "76be36c6-48e8-4201-bde6-71e32fab4f00"
           }
         ]
       }
     }
   }
   ```

